### PR TITLE
Server admin

### DIFF
--- a/db/config/default.json
+++ b/db/config/default.json
@@ -1,0 +1,5 @@
+{
+    "MONGO_URI":"mongodb://localhost:27017/realDB",
+    "PORT":"4000",
+    "HASH_SECRET_KEY":"This key should be never used. Change it when you deploy."
+}

--- a/db/config/dev.json
+++ b/db/config/dev.json
@@ -1,0 +1,5 @@
+{
+    "MONGO_URI":"mongodb://localhost:27017/devDB",
+    "PORT":"4002",
+    "HASH_SECRET_KEY":"devSecretKey"
+}

--- a/db/config/test.json
+++ b/db/config/test.json
@@ -1,0 +1,5 @@
+{
+    "MONGO_URI":"mongodb://localhost:27017/testDB",
+    "PORT":"4000",
+    "HASH_SECRET_KEY":"testSecretKey"
+}

--- a/db/package.json
+++ b/db/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "cross-env NODE_PATH=src NODE_ENV=dev nodemon --watch src/ src/index.js",
     "start": "node src/index.js",
+    "test": "cross-env NODE_PATH=src NODE_ENV=test nodemon --watch test/ --exec \"mocha  --timeout 10000 || true\"",
+    "mocha":"cross-env NODE_PATH=src NODE_ENV=test mocha --watch test/ --timeout 10000"
   },
   "dependencies": {
     "config": "^2.0.1",

--- a/db/package.json
+++ b/db/package.json
@@ -11,7 +11,10 @@
     "cross-env": "^5.2.0",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",
-    "mongoose": "^5.2.6"
+    "mongoose": "^5.2.6",
+    "passport": "^0.4.0",
+    "passport-local": "^1.0.0",
+    "passport-local-mongoose": "^5.0.1"
   },
   "devDependencies": {
     "nodemon": "^1.18.3"

--- a/db/package.json
+++ b/db/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_PATH=src NODE_ENV=dev nodemon --watch src/ src/index.js",
     "start": "node src/index.js",
-    "test": "cross-env NODE_PATH=src NODE_ENV=test nodemon --watch test/ --exec \"mocha  --timeout 10000 || true\"",
-    "mocha":"cross-env NODE_PATH=src NODE_ENV=test mocha --watch test/ --timeout 10000"
+    "test": "cross-env NODE_PATH=src NODE_ENV=test mocha --watch test/ --timeout 10000"
   },
   "dependencies": {
     "config": "^2.0.1",

--- a/db/package.json
+++ b/db/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "config": "^2.0.1",
     "cross-env": "^5.2.0",
-    "dotenv": "^6.0.0",
     "express": "^4.16.3",
     "mongoose": "^5.2.6",
     "passport": "^0.4.0",

--- a/db/package.json
+++ b/db/package.json
@@ -18,6 +18,9 @@
     "passport-local-mongoose": "^5.0.1"
   },
   "devDependencies": {
+    "chai": "^4.1.2",
+    "chai-http": "^4.0.0",
+    "mocha": "^5.2.0",
     "nodemon": "^1.18.3"
   }
 }

--- a/db/package.json
+++ b/db/package.json
@@ -4,10 +4,11 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env NODE_PATH=src nodemon --watch src/ src/index.js",
-    "start":"node src/index.js"
+    "dev": "cross-env NODE_PATH=src NODE_ENV=dev nodemon --watch src/ src/index.js",
+    "start": "node src/index.js",
   },
   "dependencies": {
+    "config": "^2.0.1",
     "cross-env": "^5.2.0",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",

--- a/db/src/api/v1.0/admin/admin.ctrl.js
+++ b/db/src/api/v1.0/admin/admin.ctrl.js
@@ -17,7 +17,8 @@ exports.checkName = async (ctx, res) => {
         });
         return;
     } catch (e) {
-        ctx.throw(e, 500);
+        console.log(e);
+        res.status(500, e).json(e);
     }
 };
 
@@ -43,6 +44,8 @@ exports.register = async (req, res) => {
             _id: admin._id
         });
     } catch (e) {
+        console.log(e);
+        res.status(500).json({error: e});
         res.status(500).json({error: e});
     }
 }

--- a/db/src/api/v1.0/admin/admin.ctrl.js
+++ b/db/src/api/v1.0/admin/admin.ctrl.js
@@ -38,7 +38,7 @@ exports.register = async (req, res) => {
             admin,
             password
         );
-
+        
         res.status(201).json({
             username,
             _id: admin._id
@@ -57,10 +57,11 @@ exports.login = async (req, res) => {
         
         if(user){
             res.status(200).json({
+                success:true,
                 user
             });
         } else{
-            res.status(401).json({});
+            res.status(401).json({success:false});
         }
 
     } catch (e) {

--- a/db/src/api/v1.0/admin/admin.ctrl.js
+++ b/db/src/api/v1.0/admin/admin.ctrl.js
@@ -11,7 +11,7 @@ exports.checkName = async (ctx, res) => {
     }
 
     try {
-        const account = await Admin.findByName(name);
+        const account = await Admin.findByUserName(name);
         res.send({
             exists: !!account
         });
@@ -23,21 +23,23 @@ exports.checkName = async (ctx, res) => {
 
 exports.register = async (req, res) => {
     const { body } = req;
-    const { name } = body;
-
+    const { username, password } = body;
     try{
-        const exists = await Admin.findByName(name);
+        const exists = await Admin.findByUserName(username);
         if(exists){
-            res.status(409).json({conflict:'name', name});
+            res.status(409).json({conflict:'username', username});
             return;
         }
 
-        const admin = await Admin.register({
-            name
-        });
+        let admin = new Admin({username});
+ 
+        admin = await Admin.register(
+            admin,
+            password
+        );
 
         res.status(201).json({
-            name,
+            username,
             _id: admin._id
         });
     } catch (e) {

--- a/db/src/api/v1.0/admin/admin.ctrl.js
+++ b/db/src/api/v1.0/admin/admin.ctrl.js
@@ -46,6 +46,25 @@ exports.register = async (req, res) => {
     } catch (e) {
         console.log(e);
         res.status(500).json({error: e});
+    }
+}
+
+exports.login = async (req, res) => {
+    const { body } = req;
+    const { username, password } = body;
+    try{
+        const { user } = await Admin.authenticate()(username, password);
+        
+        if(user){
+            res.status(200).json({
+                user
+            });
+        } else{
+            res.status(401).json({});
+        }
+
+    } catch (e) {
+        console.log(e);
         res.status(500).json({error: e});
     }
 }

--- a/db/src/api/v1.0/admin/index.js
+++ b/db/src/api/v1.0/admin/index.js
@@ -4,5 +4,6 @@ const adminCtrl = require('./admin.ctrl');
 
 admin.get('/exists/name/:name', adminCtrl.checkName);
 admin.post('/register/local', adminCtrl.register);
+admin.post('/login', adminCtrl.login);
 
 module.exports = admin;

--- a/db/src/index.js
+++ b/db/src/index.js
@@ -3,13 +3,15 @@ const express = require('express')
 const app = express()
 const mdb = require('./models');
 const api = require('./api');
+const passport = require('passport');
+const Admin = require('models/Admin');
 
-const { PORT } = process.env;
+passport.use(Admin.createStrategy());
 const port = PORT ? PORT : 4000;
 
-mdb.connect();
-
 app.use(express.json());
+app.use(passport.initialize());
+
 
 app.get('/', (req, res) => {
     res.send('hello world');
@@ -20,6 +22,7 @@ router.use('/api', api);
 
 app.use(router);
 
+mdb.connect();
 app.listen(port, () => {
     console.log(`server is running at port: ${port}`)
 });

--- a/db/src/index.js
+++ b/db/src/index.js
@@ -28,4 +28,9 @@ app.use(router);
 mdb.connect();
 app.listen(port, () => {
     console.log(`server is running at port: ${port}`)
-});
+}); app.listen(port, () => {
+        console.log(`server is running at port: ${port}`)
+    });
+}
+
+module.exports = app;

--- a/db/src/index.js
+++ b/db/src/index.js
@@ -26,9 +26,9 @@ router.use('/api', api);
 app.use(router);
 
 mdb.connect();
-app.listen(port, () => {
-    console.log(`server is running at port: ${port}`)
-}); app.listen(port, () => {
+
+if(process.env.NODE_ENV != 'test'){
+    app.listen(port, () => {
         console.log(`server is running at port: ${port}`)
     });
 }

--- a/db/src/index.js
+++ b/db/src/index.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const express = require('express')
 const app = express()
 const mdb = require('./models');
@@ -7,6 +6,10 @@ const passport = require('passport');
 const Admin = require('models/Admin');
 
 passport.use(Admin.createStrategy());
+
+let config = require('config'); //we load the db location from the JSON files
+
+const { PORT } = config;
 const port = PORT ? PORT : 4000;
 
 app.use(express.json());

--- a/db/src/index.js
+++ b/db/src/index.js
@@ -7,7 +7,7 @@ const Admin = require('models/Admin');
 
 passport.use(Admin.createStrategy());
 
-let config = require('config'); //we load the db location from the JSON files
+let config = require('config');
 
 const { PORT } = config;
 const port = PORT ? PORT : 4000;

--- a/db/src/models/Admin.js
+++ b/db/src/models/Admin.js
@@ -1,20 +1,26 @@
 const mongoose = require('mongoose');
-const { Schema } = mongoose;
+const passportLocalMongoose = require('passport-local-mongoose');
+
+const {
+    Schema
+} = mongoose;
 
 const Admin = new Schema({
-    name: Schema.Types.String
+    username: String,
+    email: String,
+    password: String
 })
 
-Admin.statics.findByName = function (name){
-    return this.findOne({name}).exec();
+Admin.plugin(passportLocalMongoose);
+
+Admin.statics.findByUserName = function (username) {
+    return this.findOne({
+        username
+    }).exec();
 }
 
-Admin.statics.register = function({name}){
-    const admin = new this({
-        name
-    });
-
-    return admin.save();
-}
+Admin.statics.drop = function () {
+    return this.remove({}).exec();
+};
 
 module.exports = mongoose.model('Admin', Admin);

--- a/db/src/models/Admin.js
+++ b/db/src/models/Admin.js
@@ -23,4 +23,4 @@ Admin.statics.drop = function () {
     return this.remove({}).exec();
 };
 
-module.exports = mongoose.model('Admin', Admin);
+module.exports = mongoose.models.Admin || mongoose.model('Admin', Admin);

--- a/db/src/models/index.js
+++ b/db/src/models/index.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
-const {
-    MONGO_URI: mongoURI
-} = process.env
+const config = require('config');
+const { MONGO_URI } = config;
+const mongoURI = MONGO_URI ? MONGO_URI : 27017;
 
 const connect = () => {
     mongoose.connect(mongoURI, { useNewUrlParser: true });

--- a/db/test/admin.js
+++ b/db/test/admin.js
@@ -1,0 +1,47 @@
+//During the test the env variable is set to test
+process.env.NODE_ENV = 'test';
+let users
+
+let mongoose = require("mongoose");
+let Admin = require('models/Admin');
+
+const config = require('config');
+
+//Require the dev-dependencies
+let chai = require('chai');
+let chaiHttp = require('chai-http');
+// let app = require('index');
+// var server;
+let should = chai.should();
+let expect = chai.expect;
+chai.use(chaiHttp);
+
+describe('Admins', () => {
+    before((done) => {
+        // server = app.start(done);
+        // console.log('remove all admin');
+        Admin.drop();
+        done();
+    })
+    beforeEach((done) => { //Before each test
+        done();
+    });
+
+    after((done)=>{
+        // server.close();
+        done();
+    });
+
+    describe('/admin', () => {
+        it('/exists/helow1 should tell admin helow1 not exists', (done) => {
+            chai.request(server)
+                .get('/api/v1.0/admin/exists/name/helow1')
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body.exists).to.equal(false);
+                    done();
+                });
+        });
+    });
+});

--- a/db/test/admin.js
+++ b/db/test/admin.js
@@ -65,5 +65,27 @@ describe('Admins', () => {
                     done();
                 });
         });
+        it('/login should fail with incorrect password', (done) => {
+            chai.request(server)
+                .post('/api/v1.0/admin/login')
+                .send({"username":"helow1","password":"asdasd2"})
+                .end((err, res) => {
+                    res.should.have.status(401);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body.success).to.equal(false);
+                    done();
+                });
+        });
+        it('/login should success with correct password', (done) => {
+            chai.request(server)
+                .post('/api/v1.0/admin/login')
+                .send({"username":"helow1","password":"asdasd"})
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body.success).to.equal(true);
+                    done();
+                });
+        });
     });
 });

--- a/db/test/admin.js
+++ b/db/test/admin.js
@@ -1,34 +1,17 @@
-//During the test the env variable is set to test
-process.env.NODE_ENV = 'test';
-let users
-
-let mongoose = require("mongoose");
 let Admin = require('models/Admin');
 
-const config = require('config');
-
-//Require the dev-dependencies
 let chai = require('chai');
 let chaiHttp = require('chai-http');
-// let app = require('index');
-// var server;
 let should = chai.should();
 let expect = chai.expect;
 chai.use(chaiHttp);
 
 describe('Admins', () => {
     before((done) => {
-        // server = app.start(done);
-        // console.log('remove all admin');
-        Admin.drop();
+        Admin.drop(); // remove all admins
         done();
     })
     beforeEach((done) => { //Before each test
-        done();
-    });
-
-    after((done)=>{
-        // server.close();
         done();
     });
 
@@ -45,13 +28,14 @@ describe('Admins', () => {
         });
         it('/register/local should add a new admin', (done) => {
             chai.request(server)
-                // .post(`{'name':'helow1','password':'asdasd'}`)
                 .post('/api/v1.0/admin/register/local')
-                .send({"username":"helow1","password":"asdasd"})
+                .send({
+                    "username": "helow1",
+                    "password": "asdasd"
+                })
                 .end((err, res) => {
                     res.should.have.status(201);
                     expect(res.body).to.be.an('object');
-                    // expect(res.body.exists).to.equal(false);
                     done();
                 });
         });
@@ -68,7 +52,10 @@ describe('Admins', () => {
         it('/login should fail with incorrect password', (done) => {
             chai.request(server)
                 .post('/api/v1.0/admin/login')
-                .send({"username":"helow1","password":"asdasd2"})
+                .send({
+                    "username": "helow1",
+                    "password": "asdasd2"
+                })
                 .end((err, res) => {
                     res.should.have.status(401);
                     expect(res.body).to.be.an('object');
@@ -79,7 +66,10 @@ describe('Admins', () => {
         it('/login should success with correct password', (done) => {
             chai.request(server)
                 .post('/api/v1.0/admin/login')
-                .send({"username":"helow1","password":"asdasd"})
+                .send({
+                    "username": "helow1",
+                    "password": "asdasd"
+                })
                 .end((err, res) => {
                     res.should.have.status(200);
                     expect(res.body).to.be.an('object');

--- a/db/test/admin.js
+++ b/db/test/admin.js
@@ -43,5 +43,27 @@ describe('Admins', () => {
                     done();
                 });
         });
+        it('/register/local should add a new admin', (done) => {
+            chai.request(server)
+                // .post(`{'name':'helow1','password':'asdasd'}`)
+                .post('/api/v1.0/admin/register/local')
+                .send({"username":"helow1","password":"asdasd"})
+                .end((err, res) => {
+                    res.should.have.status(201);
+                    expect(res.body).to.be.an('object');
+                    // expect(res.body.exists).to.equal(false);
+                    done();
+                });
+        });
+        it('/exists/helow1 should tell admin helow1 now exists', (done) => {
+            chai.request(server)
+                .get('/api/v1.0/admin/exists/name/helow1')
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    expect(res.body).to.be.an('object');
+                    expect(res.body.exists).to.equal(true);
+                    done();
+                });
+        });
     });
 });

--- a/db/test/mocha.opts
+++ b/db/test/mocha.opts
@@ -1,0 +1,3 @@
+--recursive
+--reporter spec
+--require ./test/server.bootstrap

--- a/db/test/server.bootstrap
+++ b/db/test/server.bootstrap
@@ -3,8 +3,6 @@ const config = require('config');
 let app = require('index');
 
 global.app = app;
-// global.server = app.start(()=>{});
-
 global.server = app.listen(config.PORT, () => {
     console.log(`server is running at port: ${config.PORT}`)
 });

--- a/db/test/server.bootstrap
+++ b/db/test/server.bootstrap
@@ -1,0 +1,10 @@
+const config = require('config');
+
+let app = require('index');
+
+global.app = app;
+// global.server = app.start(()=>{});
+
+global.server = app.listen(config.PORT, () => {
+    console.log(`server is running at port: ${config.PORT}`)
+});

--- a/db/test/testapi.js
+++ b/db/test/testapi.js
@@ -1,0 +1,37 @@
+//During the test the env variable is set to test
+process.env.NODE_ENV = 'test';
+
+let mongoose = require("mongoose");
+
+const config = require('config');
+
+//Require the dev-dependencies
+let chai = require('chai');
+let chaiHttp = require('chai-http');
+// let app = require('index');
+// var server;
+let should = chai.should();
+let expect = chai.expect;
+chai.use(chaiHttp);
+
+describe('Test api', () => {
+    before((done) => {
+        // server = app.start(done);
+        done();
+    })
+
+    after((done)=>{
+        // server.close();
+        done();
+    });
+
+    it('/testApi should return 418 im a teapot error', (done) => {
+        chai.request(server)
+            .get('/api/v1.0/testApi')
+            .end((err, res) => {
+                res.should.have.status(418);
+                expect(res.body).to.be.an('object');
+                done();
+            });
+    });
+});

--- a/db/test/testapi.js
+++ b/db/test/testapi.js
@@ -1,29 +1,11 @@
-//During the test the env variable is set to test
-process.env.NODE_ENV = 'test';
-
-let mongoose = require("mongoose");
-
-const config = require('config');
-
-//Require the dev-dependencies
 let chai = require('chai');
 let chaiHttp = require('chai-http');
-// let app = require('index');
-// var server;
+
 let should = chai.should();
 let expect = chai.expect;
 chai.use(chaiHttp);
 
 describe('Test api', () => {
-    before((done) => {
-        // server = app.start(done);
-        done();
-    })
-
-    after((done)=>{
-        // server.close();
-        done();
-    });
 
     it('/testApi should return 418 im a teapot error', (done) => {
         chai.request(server)

--- a/db/yarn.lock
+++ b/db/yarn.lock
@@ -135,6 +135,10 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -148,6 +152,10 @@ async@2.6.1:
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
     lodash "^4.17.10"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
 atob@^2.1.1:
   version "2.1.1"
@@ -234,6 +242,10 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
 bson@~1.0.4, bson@~1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.0.9.tgz#12319f8323b1254739b7c6bef8d3e89ae05a2f57"
@@ -278,6 +290,27 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
+chai-http@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-4.0.0.tgz#810f579e98ae9d7847701759de7682361f2f286f"
+  dependencies:
+    cookiejar "^2.1.1"
+    is-ip "^2.0.0"
+    methods "^1.1.2"
+    qs "^6.5.1"
+    superagent "^3.7.0"
+
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -299,6 +332,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@^2.0.2:
   version "2.0.4"
@@ -379,7 +416,17 @@ color-name@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
-component-emitter@^1.2.1:
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -395,6 +442,12 @@ concat-stream@^1.6.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+config@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/config/-/config-2.0.1.tgz#995ccc8175460578d646ac0a2e4018ffa44ca046"
+  dependencies:
+    json5 "^1.0.1"
 
 configstore@^3.0.0:
   version "3.1.2"
@@ -426,6 +479,10 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+cookiejar@^2.1.0, cookiejar@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -486,6 +543,12 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -525,6 +588,10 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -545,6 +612,10 @@ detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 doctrine@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -556,10 +627,6 @@ dot-prop@^4.1.0:
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
     is-obj "^1.0.0"
-
-dotenv@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -581,7 +648,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -757,6 +824,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^2.0.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -841,6 +912,18 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
+form-data@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
+formidable@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -893,6 +976,14 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+generaterr@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/generaterr/-/generaterr-1.5.0.tgz#b0ceb6cc5164df2a061338cc340a8615395c52fc"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -908,7 +999,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -960,6 +1051,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -1000,6 +1095,10 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 http-errors@1.6.2:
   version "1.6.2"
@@ -1084,6 +1183,10 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
 
 ipaddr.js@1.8.0:
   version "1.8.0"
@@ -1188,6 +1291,12 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  dependencies:
+    ip-regex "^2.0.0"
+
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -1289,6 +1398,12 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
+
 kareem@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.2.1.tgz#9950809415aa3cde62ab43b4f7b919d99816e015"
@@ -1377,7 +1492,7 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -1403,7 +1518,7 @@ mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
-mime-types@~2.1.18:
+mime-types@^2.1.12, mime-types@~2.1.18:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   dependencies:
@@ -1413,11 +1528,15 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1451,11 +1570,27 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
 
 mongodb-core@3.1.0:
   version "3.1.0"
@@ -1723,6 +1858,33 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
+passport-local-mongoose@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/passport-local-mongoose/-/passport-local-mongoose-5.0.1.tgz#7b45ae6bcb6e8a7be26a4a95a7787e4d14130fc7"
+  dependencies:
+    debug "^3.1.0"
+    generaterr "^1.5.0"
+    passport-local "^1.0.0"
+    scmp "^2.0.0"
+    semver "^5.5.0"
+
+passport-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/passport-local/-/passport-local-1.0.0.tgz#1fe63268c92e75606626437e3b906662c15ba6ee"
+  dependencies:
+    passport-strategy "1.x.x"
+
+passport-strategy@1.x.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
+
+passport@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/passport/-/passport-0.4.0.tgz#c5095691347bd5ad3b5e180238c3914d16f05811"
+  dependencies:
+    passport-strategy "1.x.x"
+    pause "0.0.1"
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -1743,11 +1905,19 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   dependencies:
     through "~2.3"
+
+pause@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -1822,6 +1992,10 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+qs@^6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+
 range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -1844,7 +2018,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2:
+readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -1985,6 +2159,10 @@ saslprep@^1.0.0:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+scmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/scmp/-/scmp-2.0.0.tgz#247110ef22ccf897b13a3f0abddb52782393cd6a"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -2204,15 +2382,30 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+superagent@^3.7.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
-supports-color@^5.2.0, supports-color@^5.3.0:
+supports-color@5.4.0, supports-color@^5.2.0, supports-color@^5.3.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
 table@^4.0.1:
   version "4.0.3"
@@ -2294,6 +2487,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"


### PR DESCRIPTION
- Applied passport-local-mongoose schema plugin to admin model
- Replaced dotenv with config package
- Added some test for admin api
* Use config files by setting `package.json` commands' `NODE_ENV` variable. 
For example, If you run `start: "NODE_PATH=dev123 node src/index.js` command, it will use `dev123.json` in config folder. `cross-env` in `dev` command is for Windows compatibility.